### PR TITLE
feat: add users/circulartree.json

### DIFF
--- a/catalog/users/circulartree.json
+++ b/catalog/users/circulartree.json
@@ -2,7 +2,7 @@
   "id": "circulartree",
   "kind": "solutionprovider",
   "name": "CircularTree",
-  "email": "",
+  "email": "info@circulartree.com",
   "website": "https://www.circulartree.com/",
-  "logo": ""
+  "logo": "https://i.ibb.co/9hZSsW1/Circular-Tree-logo-horizontal-color-transparent.png"
 }


### PR DESCRIPTION
@helloanil 
In order to make sure that the information about CircularTree is displayed correctly (e.g., with the company name 'CircularTree' rather than the user id 'circulartree'), we need to have also a user `json`. This will also allow us to display CircularTree's name, website and logo in the collaborators page.

I took the liberty to pre-fill a `json` with the data we already have and would ask you, if you agree, to double-check that it is correct, as well as add the fields missing (email and logo). I hope that's fine! 

Once you give us the heads up, we can then merge it. 

We apologize for not having asked for this sooner 
and thank you for your cooperation! 