### PR TITLE
Corrected conformance test for SDX (tested by ClimateCamp)

### DIFF
--- a/catalog/conformance-tests/result-sdx-001.json
+++ b/catalog/conformance-tests/result-sdx-001.json
@@ -9,6 +9,6 @@
   },
   "test_result": "passed",
   "test_date": "2023-12-11T09:00:00Z",
-  "pathfinder_version": "2.0.1",
+  "pathfinder_version": "2.1.0",
   "extensions_tested": []
 }


### PR DESCRIPTION
Corrected conformance test for SDX (tested by ClimateCamp) by changing pathfinder_version from 2.0.1 to 2.1.0.