### PR TITLE
fix: test result date typo (2023->2024)

### DIFF
--- a/catalog/conformance-tests/result-sdx-002.json
+++ b/catalog/conformance-tests/result-sdx-002.json
@@ -8,7 +8,7 @@
     "version": "1.0.0"
   },
   "test_result": "passed",
-  "test_date": "2023-01-12T09:00:00Z",
+  "test_date": "2024-01-12T09:00:00Z",
   "pathfinder_version": "2.1.0",
   "extensions_tested": []
 }


### PR DESCRIPTION
@19-SD We noticed that your test result with Optchain dated from January 2023 instead of 2024 and fixed it to avoid confusion. Please let us know whether this date is correct. Thank you!

Cc: @prasadt1, @ArunavC 