### PR TITLE
fix: use consistent carboledger version (2.0.0)

### DIFF
--- a/catalog/conformance-tests/result-carbontrail-001.json
+++ b/catalog/conformance-tests/result-carbontrail-001.json
@@ -5,7 +5,7 @@
   },
   "tested_by": {
     "solution_id": "carboledger",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "test_result": "passed",
   "test_date": "2023-07-01T09:00:00Z",

--- a/catalog/conformance-tests/result-climatecamp-001.json
+++ b/catalog/conformance-tests/result-climatecamp-001.json
@@ -5,7 +5,7 @@
   },
   "tested_by": {
     "solution_id": "carboledger",
-    "version": "1.0.0"
+    "version": "2.0.0"
   },
   "test_result": "passed",
   "test_date": "2023-07-13T09:00:00Z",


### PR DESCRIPTION
@nikhagarg, we noticed that Carboledger's version was inconsistent in the catalog: mostly it was 2.0.0 but in some test results it was 1.0.0.
We thought this was a typo and corrected it in this PR. Can you please confirm this?

Thank you!
Cc: @prasadt1 